### PR TITLE
getMongoData JSON streaming + verbosity options

### DIFF
--- a/getMongoData/getMongoData.js
+++ b/getMongoData/getMongoData.js
@@ -56,7 +56,7 @@
  * limitations under the License.
  */
 
-var _version = "3.1.0";
+var _version = "3.2.0";
 
 (function () {
    "use strict";

--- a/getMongoData/getMongoData.js
+++ b/getMongoData/getMongoData.js
@@ -223,7 +223,8 @@ function removeUnnecessaryCommandFields(object) {
     });
 }
 
-var _JSONPrefix = "";
+var _firstJSONArrayElement = true;
+var _jsonOutBuffer = ""; 
 function printInfo(message, command, section, printCapture, commandParameters) {
     var result = false;
     if (typeof printCapture === "undefined") var printCapture = false;
@@ -275,8 +276,14 @@ function printInfo(message, command, section, printCapture, commandParameters) {
 
     // Stream JSON array element.
     if (_printJSON) {
-        print(_JSONPrefix, JSON.stringify(doc, jsonStringifyReplacer, 4));
-        _JSONPrefix = ",";
+        if (_firstJSONArrayElement) {
+            _jsonOutBuffer = JSON.stringify(doc, jsonStringifyReplacer, 4);
+            _firstJSONArrayElement = false;
+        }
+        else {
+            print(_jsonOutBuffer, ",");
+            _jsonOutBuffer = JSON.stringify(doc, jsonStringifyReplacer, 4);
+        }
     }
 
     if (! _printJSON) printjson(result);
@@ -678,6 +685,9 @@ try {
 }
 
 if (_printJSON) {
+    if (_jsonOutBuffer) {
+        print(_jsonOutBuffer);
+    }
     print("]");
 }
 

--- a/getMongoData/getMongoData.js
+++ b/getMongoData/getMongoData.js
@@ -56,7 +56,7 @@
  * limitations under the License.
  */
 
-// Potentially breaking changes in "4.0.0" with respect to "3.2.0":
+// Potentially breaking changes in "4.0.0" with respect to "3.1.0":
 //  -   _printJSON with _maxCollections no longer renames sections with "INCOMPLETE_" prefix when 
 //      _maxCollections is reached. Instead, the last element of the output JSON array contains an 
 //      error message.

--- a/getMongoData/getMongoData.js
+++ b/getMongoData/getMongoData.js
@@ -56,7 +56,12 @@
  * limitations under the License.
  */
 
-var _version = "3.2.0";
+// Potentially breaking changes in "4.0.0" with respect to "3.2.0":
+//  -   _printJSON with _maxCollections no longer renames sections with "INCOMPLETE_" prefix when 
+//      _maxCollections is reached. Instead, the last element of the output JSON array contains an 
+//      error message.
+//  -   _printJSON outputs error messages after the JSON array is printed, instead of before. 
+var _version = "4.0.0";
 
 (function () {
    "use strict";

--- a/getMongoData/getMongoData.js
+++ b/getMongoData/getMongoData.js
@@ -223,7 +223,6 @@ function removeUnnecessaryCommandFields(object) {
     });
 }
 
-var _firstJSONArrayElement = true;
 var _jsonOutBuffer = ""; 
 function printInfo(message, command, section, printCapture, commandParameters) {
     var result = false;
@@ -276,9 +275,8 @@ function printInfo(message, command, section, printCapture, commandParameters) {
 
     // Stream JSON array element.
     if (_printJSON) {
-        if (_firstJSONArrayElement) {
+        if (!_jsonOutBuffer) {
             _jsonOutBuffer = JSON.stringify(doc, jsonStringifyReplacer, 4);
-            _firstJSONArrayElement = false;
         }
         else {
             print(_jsonOutBuffer, ",");


### PR DESCRIPTION
- Make getMongoData.js stream json output instead of building the whole array in-memory.
  -  `updateDataInfoAsIncomplete` is removed, on exceeding `_maxCollections`, subsections are no longer renamed to prefix "INCOMPLETE\_". Instead, the last array element contains an error message.
- Add `_printWiredTigerDetails` option to remove wired tiger details
- Add `_verbose` option to remove 
  - redundant fields on each array element (tag, ref, version, etc.)
  - unnecessary fields in command responses ($clusterTime,...)
- Add `_suppressError` option to keep the output parsable JSON even in the presence of an error.
  - To be combined with `mongo --quiet`

Sample output (capped at 10 collections): https://privatebin.corp.mongodb.com/?8ae6bcda82ff9261#9xxqXPmTGKQxakU8hCF28k8qbNNRSDdYTbQF9PFdcoyd

On test environment with 10k databases each with:
- 5 collections + 1 view
- 22 user created indexes (distributed in 2 of the collections)

`var _printWiredTigerDetails=false; var _verbose=false;` reduces the file size from 2.7GB down to 340MB.

e.g.
```
mongo --port 27017 --quiet --eval "var _maxCollections = 100000; var _suppressError=true; var _printWiredTigerDetails=false; var _verbose=false;" getMongoData.js > getMongoData.json
```